### PR TITLE
Fix 2018 staff icon style

### DIFF
--- a/2018/index.html
+++ b/2018/index.html
@@ -226,60 +226,60 @@
 
         <div class="row">
 
-          <div class="col-md-3 staff">
+          <div class="col-md-3 col-sm-4 col-6 staff">
             <h4>Tatsuhiro Ujihisa</h4>
             <p>&nbsp;</p>
-            <img src="icon/ujm.png" />
+            <img src="icon/ujm.png" class="staff-icon" />
             <p>
             <a href="https://github.com/ujihisa"><img src="https://assets-cdn.github.com/images/modules/logos_page/GitHub-Mark.png" width="32" height="32" /></a>
             <a href="https://twitter.com/ujm"><img src="https://embed.gyazo.com/5f0c9cc6e0515266bef0bf736ff21213.png" width="32" height="32" /></a>
             </p>
             <p>Created this webpage. Created aomoriringo's profile avatar. Published some VimConf official blog posts. He has been using Vim for about 20 years.</p>
           </div>
-          <div class="col-md-3 staff">
+          <div class="col-md-3 col-sm-4 col-6 staff">
             <h4>Taro Muraoka</h4>
             <p>also known as <strong>KaoriYa</strong></p>
-            <img src="icon/koron.png" />
+            <img src="icon/koron.png" class="staff-icon" />
             <p>TBD</p>
           </div>
-          <div class="col-md-3 staff">
+          <div class="col-md-3 col-sm-4 col-6 staff">
             <h4>thinca</h4>
             <p>&nbsp;</p>
-            <img src="icon/thinca.png" />
+            <img src="icon/thinca.png" class="staff-icon" />
             <p>TBD</p>
           </div>
-          <div class="col-md-3 staff">
+          <div class="col-md-3 col-sm-4 col-6 staff">
             <h4>aomoriringo</h4>
             <p>&nbsp;</p>
-            <img src="icon/aomoriringo.png" />
+            <img src="icon/aomoriringo.png" class="staff-icon" />
             <p>TBD</p>
           </div>
-          <div class="col-md-3 staff">
+          <div class="col-md-3 col-sm-4 col-6 staff">
             <h4>mopp</h4>
             <p>&nbsp;</p>
-            <img src="icon/mopp.png" />
+            <img src="icon/mopp.png" class="staff-icon" />
             <p>TBD</p>
           </div>
-          <div class="col-md-3 staff">
+          <div class="col-md-3 col-sm-4 col-6 staff">
             <h4>Yasuhiro Matsumoto</h4>
             <p>also known as <strong>mattn</strong></p>
-            <img src="icon/mattn.png" />
+            <img src="icon/mattn.png" class="staff-icon" />
             <p>
             <a href="https://github.com/mattn"><img src="https://assets-cdn.github.com/images/modules/logos_page/GitHub-Mark.png" width="32" height="32" /></a>
             <a href="https://twitter.com/mattn_jp"><img src="https://embed.gyazo.com/5f0c9cc6e0515266bef0bf736ff21213.png" width="32" height="32" /></a>
             </p>
             <p>A programmer that contributes to Vim and Go and many other OSS(s). Has over 1,400 GitHub repositories.</p>
           </div>
-          <div class="col-md-3 staff">
+          <div class="col-md-3 col-sm-4 col-6 staff">
             <h4>t9md</h4>
             <p>&nbsp;</p>
-            <img src="icon/t9md.png" />
+            <img src="icon/t9md.png" class="staff-icon" />
             <p>TBD</p>
           </div>
-          <div class="col-md-3 staff">
+          <div class="col-md-3 col-sm-4 col-6 staff">
             <h4>guyon</h4>
             <p>&nbsp;</p>
-            <img src="icon/guyon.png" />
+            <img src="icon/guyon.png" class="staff-icon" />
             <p>TBD</p>
           </div>
 

--- a/2018/style.css
+++ b/2018/style.css
@@ -61,10 +61,6 @@
 	margin-bottom: 50px;
 }
 
-.staff {
-	width: 150px;
-}
-
 .staff img {
 	margin: auto;
 }
@@ -72,4 +68,8 @@
 .staff p {
 	text-align: left;
 	font-size: 0.6em;
+}
+
+.staff-icon {
+  width: 100%;
 }


### PR DESCRIPTION
スマホ等で見た場合にスタッフのアイコンが隣と重なっていたので直しました。
こちらで確認できます。https://y0za.github.io/vimconf.org/2018/

Before
<img width="420" alt="vimconf_2018_staff_icon" src="https://user-images.githubusercontent.com/16757772/43706017-284f2874-999f-11e8-9f0d-11cd0d135117.png">

After
<img width="418" alt="vimconf_2018_staff_icon_after" src="https://user-images.githubusercontent.com/16757772/43706167-95e6f614-999f-11e8-821e-79eaefd9d239.png">
