### PR TITLE
Replace link to ticket detail to new URL

### DIFF
--- a/2018/index.html
+++ b/2018/index.html
@@ -114,7 +114,7 @@
           <div class="col-4">
             <p><a class="btn btn-secondary" href="https://vimconf2018-ticket.peatix.com/" role="button">Purchase tickets &raquo;</a></p>
             <p><a class="btn btn-secondary" href="https://vimconf2018-individual.peatix.com/" role="button">Purchase individual sponsor options independently &raquo;</a></p>
-            <p><a href="https://vimconf.wordpress.com/2018/08/30/PUT_ARTICLE_URL_HERE">Start selling at 2018-09-17</a></p>
+            <p><a href="https://vimconf.wordpress.com/2018/08/30/well-start-selling-vimconf-2018-tickets-on-2018-09-17/">Start selling at 2018-09-17</a></p>
           </div>
         </div>
 

--- a/2018/index.html
+++ b/2018/index.html
@@ -114,7 +114,7 @@
           <div class="col-4">
             <p><a class="btn btn-secondary" href="https://vimconf2018-ticket.peatix.com/" role="button">Purchase tickets &raquo;</a></p>
             <p><a class="btn btn-secondary" href="https://vimconf2018-individual.peatix.com/" role="button">Purchase individual sponsor options independently &raquo;</a></p>
-            <p><a href="https://vimconf.wordpress.com/2018/08/30/well-start-selling-vimconf-2018-tickets-on-2018-09-17/">Start selling at 2018-09-17</a></p>
+            <p><a href="https://vimconf.wordpress.com/2018/08/30/well-start-selling-vimconf-2018-tickets-on-2018-09-17/">Start selling on 2018-09-17</a></p>
           </div>
         </div>
 

--- a/2018/index.html
+++ b/2018/index.html
@@ -114,7 +114,7 @@
           <div class="col-4">
             <p><a class="btn btn-secondary" href="https://vimconf2018-ticket.peatix.com/" role="button">Purchase tickets &raquo;</a></p>
             <p><a class="btn btn-secondary" href="https://vimconf2018-individual.peatix.com/" role="button">Purchase individual sponsor options independently &raquo;</a></p>
-            <p><a href="https://vimconf.wordpress.com/2018/08/23/schedule-for-vimconf-2018-tickets/">schedule and details</a></p>
+            <p><a href="https://vimconf.wordpress.com/2018/08/30/PUT_ARTICLE_URL_HERE">Start selling at 2018-09-17</a></p>
           </div>
         </div>
 


### PR DESCRIPTION
Remove old one since it’s confusing since early bird is no longer
available now.