### PR TITLE
Add sessions page

### DIFF
--- a/2018/index.html
+++ b/2018/index.html
@@ -211,13 +211,6 @@ In Japan, He write serial articles about Vim in monthly magazine.
 
         <p>&nbsp;</p>
         <p>&nbsp;</p>
-        <p>&nbsp;</p>
-        <p>&nbsp;</p>
-        <p>&nbsp;</p>
-        <p>&nbsp;</p>
-        <p>&nbsp;</p>
-        <p>&nbsp;</p>
-
         <div class="jumbotron" id="link-sponsors">
           <h2>Sponsors</h2>
         </div>
@@ -398,7 +391,7 @@ In Japan, He write serial articles about Vim in monthly magazine.
 
         <h3><a href="#link-faq-twitter-hashtag">Q. What's the official Twitter hashtag?</a></h3>
 
-        <div class="row">
+        <div class="row col-4">
           <p>#vimconf</p>
         </div>
 

--- a/2018/index.html
+++ b/2018/index.html
@@ -22,9 +22,6 @@ title: VimConf 2018 - An international Vim Conference
             <a class="nav-link" href="#link-keynote">Keynote speakers</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="#link-speakers">Speakers</a>
-          </li>
-          <li class="nav-item">
             <a class="nav-link" href="#link-timetable">Time table</a>
           </li>
           <li class="nav-item">
@@ -164,30 +161,6 @@ In Japan, He write serial articles about Vim in monthly magazine.
             -->
           </div>
         </div>
-
-        <div class="jumbotron" id="link-speakers">
-          <h2>Speakers</h2>
-        </div>
-
-        <div class="row">
-          {% for speaker in site.data.y2018.speakers %}
-          <div class="col-md-4">
-            <h2>{{ speaker.name }}</h2>
-            <img src="{{ speaker.image }}" width="236" height="236" />
-
-            <p>
-              {% if speaker.github %}<a href="https://github.com/{{ speaker.github }}"><img src="https://assets-cdn.github.com/images/modules/logos_page/GitHub-Mark.png" width="32" height="32" alt="Link to GitHub account"/></a>{% endif %}
-              {% if speaker.twitter %}<a href="https://twitter.com/{{ speaker.twitter }}"><img src="https://embed.gyazo.com/5f0c9cc6e0515266bef0bf736ff21213.png" width="32" height="32" alt="Link to Twitter account" /></a>{% endif %}
-            </p>
-
-            <p>{{ speaker.bio }}</p>
-            <!--
-            <p><a class="btn btn-secondary" href="#" role="button">View details &raquo;</a></p>
-            -->
-          </div>
-          {% endfor %}
-        </div>
-
 
         <div class="jumbotron" id="link-timetable">
           <h2>Time Table</h2>

--- a/2018/index.html
+++ b/2018/index.html
@@ -40,6 +40,9 @@ title: VimConf 2018 - An international Vim Conference
             <a class="nav-link" href="#link-staff">Staff</a>
           </li>
           <li class="nav-item">
+            <a class="nav-link" href="sessions">Sessions</a>
+          </li>
+          <li class="nav-item">
             <a class="nav-link" href="../coc">Code of conduct</a>
           </li>
           <!--
@@ -205,7 +208,11 @@ In Japan, He write serial articles about Vim in monthly magazine.
           {% for program in site.data.y2018.timetable %}
             <tr>
               <th>{{ program.Start }} - {{ program.End }}</th>
+              {% if program.SessionID %}
+              <th><a href="sessions/#link-{{program.SessionID}}">{{ program.Content }}</a></th>
+              {% else %}
               <th>{{ program.Content }}</th>
+              {% endif %}
               <th>{{ program.Speaker }}</th>
               <th>{{ program.Language }}</th>
             </tr>

--- a/2018/index.html
+++ b/2018/index.html
@@ -193,8 +193,6 @@ In Japan, He write serial articles about Vim in monthly magazine.
           <h2>Time Table</h2>
         </div>
 
-        <p><a href="https://gist.github.com/ujihisa/393babf6619142a1248270cb4187abf5">Temporary time table with abstract</a></p>
-
         <table class="table">
           <thead class="thead-light">
             <tr>

--- a/2018/sessions.html
+++ b/2018/sessions.html
@@ -3,7 +3,7 @@ layout: 2018/default
 title: Sessions
 ---
     <nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark">
-      <a class="navbar-brand" href="#">VimConf 2018</a>
+      <a class="navbar-brand" href="../">VimConf 2018</a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
@@ -11,28 +11,28 @@ title: Sessions
       <div class="collapse navbar-collapse" id="navbarsExampleDefault">
         <ul class="navbar-nav mr-auto">
           <li class="nav-item">
-            <a class="nav-link" href="#link-tickets">Tickets</a>
+            <a class="nav-link" href="../#link-tickets">Tickets</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="#link-keynote">Keynote speakers</a>
+            <a class="nav-link" href="../#link-keynote">Keynote speakers</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="#link-speakers">Speakers</a>
+            <a class="nav-link" href="../#link-speakers">Speakers</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="#link-timetable">Time table</a>
+            <a class="nav-link" href="../#link-timetable">Time table</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="#link-side-events">Side events</a>
+            <a class="nav-link" href="../#link-side-events">Side events</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="#link-sponsors">Sponsors</a>
+            <a class="nav-link" href="../#link-sponsors">Sponsors</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="#link-faq">FAQ</a>
+            <a class="nav-link" href="../#link-faq">FAQ</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="#link-staff">Staff</a>
+            <a class="nav-link" href="../#link-staff">Staff</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="#">Sessions</a>
@@ -51,7 +51,7 @@ title: Sessions
         <h1>Sessions</h1>
         <br>
         {% for session in site.data.y2018.sessions %}
-        <div class="jumbotron" id="link-sessions">
+        <div class="jumbotron" id="link-{{ session.session_id }}">
           <h3>{{ session.title }}</h3>
         </div>
         <h4>Abstract</h4>

--- a/2018/sessions.html
+++ b/2018/sessions.html
@@ -1,0 +1,86 @@
+---
+layout: 2018/default
+title: Sessions
+---
+    <nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark">
+      <a class="navbar-brand" href="#">VimConf 2018</a>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+
+      <div class="collapse navbar-collapse" id="navbarsExampleDefault">
+        <ul class="navbar-nav mr-auto">
+          <li class="nav-item">
+            <a class="nav-link" href="#link-tickets">Tickets</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#link-keynote">Keynote speakers</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#link-speakers">Speakers</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#link-timetable">Time table</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#link-side-events">Side events</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#link-sponsors">Sponsors</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#link-faq">FAQ</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#link-staff">Staff</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#">Sessions</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="../coc">Code of conduct</a>
+          </li>
+        </ul>
+      </div>
+    </nav>
+
+    <main role="main" class="mt-5">
+
+      <div class="container">
+        <br>
+        <h1>Sessions</h1>
+        <br>
+        {% for session in site.data.y2018.sessions %}
+        <div class="jumbotron" id="link-sessions">
+          <h3>{{ session.title }}</h3>
+        </div>
+        <h4>Abstract</h4>
+        {{ session.abstract }}
+        <br><br>
+        <h4>Speaker</h4>
+        <h5>{{ session.speaker }}</h5>
+        <img src="{{ session.image }}" width="150" height="150" />
+        <br>
+        {% if session.github %}<a href="https://github.com/{{ session.github }}"><img src="https://assets-cdn.github.com/images/modules/logos_page/GitHub-Mark.png" width="32" height="32" alt="Link to GitHub account"/></a>{% endif %}
+        {% if session.twitter %}<a href="https://twitter.com/{{ session.twitter }}"><img src="https://embed.gyazo.com/5f0c9cc6e0515266bef0bf736ff21213.png" width="32" height="32" alt="Link to Twitter account" /></a>{% endif %}
+        <br>
+        {{ session.bio }}
+        <br><br>
+        {% endfor %}
+
+        <hr>
+      </div> <!-- /container -->
+    </main>
+
+    <footer class="container">
+      <p>&copy; VimConf Jumbikai 2018 -</p>
+      <p>Contact: vimconf@gmail.com</p>
+    </footer>
+
+    <!-- Bootstrap core JavaScript
+    ================================================== -->
+    <!-- Placed at the end of the document so the pages load faster -->
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery-slim.min.js"><\/script>')</script>
+    <script src="../../assets/js/vendor/popper.min.js"></script>
+    <script src="../../dist/js/bootstrap.min.js"></script>

--- a/2018/sessions.html
+++ b/2018/sessions.html
@@ -17,9 +17,6 @@ title: Sessions
             <a class="nav-link" href="../#link-keynote">Keynote speakers</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="../#link-speakers">Speakers</a>
-          </li>
-          <li class="nav-item">
             <a class="nav-link" href="../#link-timetable">Time table</a>
           </li>
           <li class="nav-item">

--- a/_data/y2018/sessions.yaml
+++ b/_data/y2018/sessions.yaml
@@ -15,7 +15,8 @@
 #   language: English
 #   abstract: >-
 
-- start_time: 13:10
+- session_id: daisuzu
+  start_time: 13:10
   end_time: 13:40
   duration: 00:30
   title: Migrating plugins to standard features
@@ -31,7 +32,8 @@
   bio: >-
     A server side engineer from a test engineer. Used Vim for various purposes in various environments, such as editing and viewing text or sometimes as a bit of tools on Windows, Linux and Mac. Currently, using Vim for daily works for developing a game platform with Google App Engine and Go.
 
-- start_time: 13:40
+- session_id: ujihisa
+  start_time: 13:40
   end_time: 14:10
   duration: 00:30
   title: Modes
@@ -55,7 +57,8 @@
     Back then he lived in Vancouver, Canada, and he's going to move back there within a year.
     Besides programming, he worked on baking breads 🥖, and is focusing on preprocessing and cook fish recently.
 
-- start_time: 14:20
+- session_id: okuramasafumi
+  start_time: 14:20
   end_time: 14:40
   duration: 00:20
   title: A day in the life of (ordinary) Vimmer
@@ -77,7 +80,8 @@
     goals efficiently. He thinks Vim is a daily power tools for every type of
     developer.
 
-- start_time: 14:40
+- session_id: tadsan
+  start_time: 14:40
   end_time: 15:00
   duration: 00:20
   title: Modern editor - independent development environment for PHP
@@ -87,11 +91,14 @@
   github: zonuexe
   twitter: tadsan
   abstract: >-
+    従来テキストエディタは重厚なIDEの対するアンチテーゼとして好まれてきた側面がありました。しかしながら今日のソフトウェア開発においては、いわゆる動的言語の開発現場においてもIDEの有用性が認められ、生産性などの観点を重視して、テキストエディタではなくIDEが推奨される事例が増えています。
+    そのような現状において、テキストエディタを使ってIDEに匹敵する言語サポートを得て開発するための手法、特に固有のエディタに依存せずにインテリジェントなPHP開発を実現するためのツール群と、EmacsとVimへの適用例について紹介します。
   bio: >-
     Vim user from 2011.  Web programmer in pixiv Inc, and current
     maintainer of Emacs PHP Mode.
 
-- start_time: 15:00
+- session_id: lambdalisue
+  start_time: 15:00
   end_time: 15:30
   duration: 00:30
   title: Effective Modern Vim scripting
@@ -112,7 +119,8 @@
     He developed and maintains Vim related plugins such as
     jupyter-vim-binding, gina.vim, suda.vim, gista.vim, and a lot more.
 
-- start_time: 15:40
+- session_id: akin
+  start_time: 15:40
   end_time: 16:10
   duration: 00:30
   title: Oni - The GUI-fication of Neovim
@@ -131,7 +139,8 @@
     Software Engineer in London, having studied medicine in a past life, currently working with Typescript and NodeJS.
     Vim fanatic using vim for all my editing needs, Collaborator on Onivim, a project aimed at breaking Vim free of terminal limitations
 
-- start_time: 16:10
+- session_id: rhysd
+  start_time: 16:10
   end_time: 16:40
   duration: 00:30
   title: Vim ported to WebAssembly
@@ -141,10 +150,7 @@
   github: rhysd
   twitter: Linda_pp
   abstract: >-
-    I've started a new project vim.wasm:
-
-    https://github.com/rhysd/vim.wasm
-
+    I've started a new project <a href="https://github.com/rhysd/vim.wasm">vim.wasm</a>.
     This is a project to port Vim editor to WebAssembly (Wasm). Wasm is a new executable format for browser. Now Vim is running on browser.
 
     In this presentation, I will explain how/why I ported Vim to Wzsm as an experimental fork.

--- a/_data/y2018/sessions.yaml
+++ b/_data/y2018/sessions.yaml
@@ -1,0 +1,160 @@
+---
+# - start_time: 10:10
+#   end_time: 11:00
+#   duration: 00:50
+#   title: Keynote - What is the next feature?
+#   speaker: Yasuhiro Matsumoto
+#   language: Japanese
+#   abstract: >-
+# 
+# - start_time: 11:10
+#   end_time: 12:10
+#   duration: 01:00
+#   title: Keynote - Vim&#58; From hjkl to a platform for plugins
+#   speaker: Bram Moolenaar
+#   language: English
+#   abstract: >-
+
+- start_time: 13:10
+  end_time: 13:40
+  duration: 00:30
+  title: Migrating plugins to standard features
+  speaker: daisuzu
+  language: Japanese
+  image: ../icon/daisuzu.png
+  github: daisuzu
+  twitter: dice_zu
+  abstract: >-
+    Although it may not be well known, Vim has a lot of useful standard features and many people use them from the plugin, but they can also be used directly.
+    Certainly plugins are important for efficient use of Vim and have used many plugins so far, but I prefer standard features rather than plugins recently.
+    In this session, I'll talk about specific method of migrating plugins to standard features, along with my own growth and changes in usage of Vim itself which is that reason.
+  bio: >-
+    A server side engineer from a test engineer. Used Vim for various purposes in various environments, such as editing and viewing text or sometimes as a bit of tools on Windows, Linux and Mac. Currently, using Vim for daily works for developing a game platform with Google App Engine and Go.
+
+- start_time: 13:40
+  end_time: 14:10
+  duration: 00:30
+  title: Modes
+  speaker: Tatsuhiro Ujihisa
+  language: English
+  image: ../icon/ujihisa.png
+  github: ujihisa
+  twitter: ujm
+  abstract: >-
+    Discover what is happening internally when you switch modes, such as insert mode, normal mode, and operator-pending mode.
+    This talk first revisits how modes are when you use Vim, then I'll let you dive into the Vim C implementation to see what's exactly happening there.
+    I'll even show what modifications can be done when you make change, with using existing pull requests.
+
+    This talk is both for Vim beginners and advanced users who don't always look at the Vim C implementation.
+  bio: >-
+    He is just a programmer who writes Ruby, Vim script, Scala, Clojure, and couple others.
+    What makes him a little bit different is that he uses Vim for over 20 years to live, and organizes couple of Vim communities, including founding this VimConf back in 2013.
+    His major contribution to Vim is to create and maintain <a href="https://github.com/vim-jp/vital.vim">vital.vim</a>, the comprehensive Vim utility functions for Vim plugins.
+
+    He currently lives in Tokyo, Japan and working at Quipper Ltd.
+    Back then he lived in Vancouver, Canada, and he's going to move back there within a year.
+    Besides programming, he worked on baking breads 🥖, and is focusing on preprocessing and cook fish recently.
+
+- start_time: 14:20
+  end_time: 14:40
+  duration: 00:20
+  title: A day in the life of (ordinary) Vimmer
+  speaker: OKURA Masafumi
+  language: English
+  image: ../icon/okuramasafumi.jpg
+  github: okuramasafumi
+  twitter: okuramasafumi
+  abstract: >-
+    This presentation shows how I, with 5 year experience of using Vim, use Vim to do my day job.
+    In this presentation I'll talk about plugins I use frequently, native features I like the most and the tips to make a terminal and Vim work along well.
+    You'll take away some plugins and techniques you've missed.
+  bio: >-
+    He's been doing Ruby/Rails development over the past five years with some
+    experience of development with Go. He started using Vim just when he
+    started his professional carrier, and is still learning to master Vim.
+    While most of the time he uses Vim for application development, sometimes
+    he does system administration work, and Vim really helps him to achieve
+    goals efficiently. He thinks Vim is a daily power tools for every type of
+    developer.
+
+- start_time: 14:40
+  end_time: 15:00
+  duration: 00:20
+  title: Modern editor - independent development environment for PHP
+  speaker: USAMI Kenta
+  language: Japanese
+  image: ../icon/zonuexe.png
+  github: zonuexe
+  twitter: tadsan
+  abstract: >-
+  bio: >-
+    Vim user from 2011.  Web programmer in pixiv Inc, and current
+    maintainer of Emacs PHP Mode.
+
+- start_time: 15:00
+  end_time: 15:30
+  duration: 00:30
+  title: Effective Modern Vim scripting
+  speaker: Alisue
+  language: English
+  image: ../icon/lambdalisue.png
+  github: lambdalisue
+  twitter: lambdalisue
+  abstract: >-
+    Coming to grips with Vim script in Vim 8.x is more than a matter of familiarizing yourself with the features they introduce (e.g., timer, job control, and lambda expression).
+    The challenge is learning to use those features effectively --- so that your plugin is correct, efficient, maintainable, and portable.
+    That's where this talk comes in. It describes how to write modern asynchronous Vim plugins using modules in vim-jp/vital.vim.
+  bio: >-
+    Software engineer who used to study biology in postgraduate course.
+    He has been using Vim about 10 years for daily work and is addicted to
+    it. He helps people to make Vim plugins by development of vital.vim
+    modules, a Vim script library produced by vim-jp.
+    He developed and maintains Vim related plugins such as
+    jupyter-vim-binding, gina.vim, suda.vim, gista.vim, and a lot more.
+
+- start_time: 15:40
+  end_time: 16:10
+  duration: 00:30
+  title: Oni - The GUI-fication of Neovim
+  speaker: Akin
+  language: English
+  image: ../icon/Akin909.jpg
+  github: Akin909
+  twitter: Akin_So
+  abstract: >-
+    Modal editing is an amazing, efficient and fun way to write code.
+    However until now has required a trade off in terms of the UI/UX of your editor as this I think is not where vim's strengths lie.
+    Oni is a typescript electron app that embeds neovim and essentially provides a modern GUI wrapper.
+    We aim to preserve the text-editing experience of neovim whilst adding a nicer UI/UX as well as IDE features.
+    This talk is about the Oni project, its current status and what we plan for Oni's future.
+  bio: >-
+    Software Engineer in London, having studied medicine in a past life, currently working with Typescript and NodeJS.
+    Vim fanatic using vim for all my editing needs, Collaborator on Onivim, a project aimed at breaking Vim free of terminal limitations
+
+- start_time: 16:10
+  end_time: 16:40
+  duration: 00:30
+  title: Vim ported to WebAssembly
+  speaker: rhysd
+  language: Japanese
+  image: ../icon/rhysd.jpg
+  github: rhysd
+  twitter: Linda_pp
+  abstract: >-
+    I've started a new project vim.wasm:
+
+    https://github.com/rhysd/vim.wasm
+
+    This is a project to port Vim editor to WebAssembly (Wasm). Wasm is a new executable format for browser. Now Vim is running on browser.
+
+    In this presentation, I will explain how/why I ported Vim to Wzsm as an experimental fork.
+    Let me share my experience porting the historic editor (which has a history of over 25 years) to a brand new web thing (Wasm); what was done well and what was an essential challenge.
+  bio: >-
+    Software engineer at Tokyo. Hobby OSS developer. Interested in tools for
+    programming such as programming languages (compilers, runtimes &amp; specs)
+    or text editors.<br>
+    Creator of NyaoVim (Neovim frontend built on Electron and Web Components)
+    and 70+ Vim plugins. Maintainer of Neovim Node.js binding, 'wast' filetype
+    in Vim runtime, and vital.vim. My current project is vim.wasm; Vim editor
+    ported to WebAssembly.
+

--- a/_data/y2018/timetable.csv
+++ b/_data/y2018/timetable.csv
@@ -1,19 +1,19 @@
-Start,End,Dur.,Content,Speaker,Language,Interp.,Misc.
-09:30,10:00,00:30,Reception,,,no,
-10:00,10:10,00:10,Opening,mopp,English,yes,
-10:10,11:00,00:50,Keynote - What is the next feature?,Yasuhiro Matsumoto,Japanese,yes,
-11:00,11:10,00:10,Short break,,,no,
-11:10,12:10,01:00,Keynote - Vim: From hjkl to a platform for plugins,Bram Moolenaar,English,yes,"Horland, Swiss"
-12:10,13:10,01:00,Lunch break,,,no,
-13:10,13:40,00:30,Migrating plugins to standard features,daisuzu,Japanese,yes,
-13:40,14:10,00:30,Modes,Tatsuhiro Ujihisa,English,yes,
-14:10,14:20,00:10,Short break,,,no,
-14:20,14:40,00:20,A day in the life of (ordinary) Vimmer,OKURA Masafumi,English,yes,
-14:40,15:00,00:20,Modern editor-independent development environment for PHP,USAMI Kenta,Japanese,yes,
-15:00,15:30,00:30,Effective Modern Vim scripting,Alisue,English,yes,
-15:30,15:40,00:10,Short break,,,no,
-15:40,16:10,00:30,Oni - The GUI-fication of Neovim,Akin,English,yes,G.B.
-16:10,16:40,00:30,Vim ported to WebAssembly,rhysd,Japanese,yes,
-16:40,17:15,00:35,Lightning Talks,(5 Speakers),Mixed,no?,5m (explain) + (1m + 5m) * 5ppl
-17:15,17:25,00:10,Closing,mopp,English,yes,
-17:30,19:30,02:00,After party,,,no,
+Start,End,Dur.,Content,Speaker,Language,Interp.,SessionID,Misc.
+09:30,10:00,00:30,Reception,,,no,,
+10:00,10:10,00:10,Opening,mopp,English,yes,,
+10:10,11:00,00:50,Keynote - What is the next feature?,Yasuhiro Matsumoto,Japanese,yes,,
+11:00,11:10,00:10,Short break,,,no,,
+11:10,12:10,01:00,Keynote - Vim: From hjkl to a platform for plugins,Bram Moolenaar,English,yes,,"Horland, Swiss"
+12:10,13:10,01:00,Lunch break,,,no,,
+13:10,13:40,00:30,Migrating plugins to standard features,daisuzu,Japanese,yes,daisuzu,
+13:40,14:10,00:30,Modes,Tatsuhiro Ujihisa,English,yes,ujihisa,
+14:10,14:20,00:10,Short break,,,no,,
+14:20,14:40,00:20,A day in the life of (ordinary) Vimmer,OKURA Masafumi,English,yes,okuramasafumi,
+14:40,15:00,00:20,Modern editor-independent development environment for PHP,USAMI Kenta,Japanese,yes,tadsan,
+15:00,15:30,00:30,Effective Modern Vim scripting,Alisue,English,yes,lambdalisue,
+15:30,15:40,00:10,Short break,,,no,,
+15:40,16:10,00:30,Oni - The GUI-fication of Neovim,Akin,English,yes,akin,G.B.
+16:10,16:40,00:30,Vim ported to WebAssembly,rhysd,Japanese,yes,rhysd,
+16:40,17:15,00:35,Lightning Talks,(5 Speakers),Mixed,no?,,5m (explain) + (1m + 5m) * 5ppl
+17:15,17:25,00:10,Closing,mopp,English,yes,,
+17:30,19:30,02:00,After party,,,no,,


### PR DESCRIPTION
Sessionsページを追加するPRです。
これまでWebサイトで公開していた情報に加え、Abstractが追加されています。

- `/sessions` ページを追加しました。
- indexページのTime tableからsessionsページへのリンクを貼りました。
- https://github.com/vim-jp/vimconf.org/commit/230a46ce20687b6d35e07a8440c289298d44cad1 の内容を削除しました。
- indexページからspeakers部分を削除しました。

USAMI KentaさんのAbstractだけ英語のものがなかったので、日本語のものをそのまま掲載しています。