### PR TITLE
Add youtube playlist, Fix '#menu-official-blog' fragment

### DIFF
--- a/2019/css/base.css
+++ b/2019/css/base.css
@@ -86,6 +86,11 @@ ul {
   animation: fadeText 500ms forwards 300ms;
 }
 
+#youtube {
+  text-align: center;
+  margin: 20px 0;
+}
+
 #billboard:hover {
   transform: scale(1.01, 1.01);
 }

--- a/2019/index.html
+++ b/2019/index.html
@@ -360,7 +360,7 @@ title: VimConf 2019 - An international Vim Conference
 
       <hr class="my-4" />
 
-      <section id="menu-blog">
+      <section id="menu-official-blog">
         <div class="panel text-center">
           <h3 id="blog">Official blog</h3>
           <strong><a href="https://vimconf.wordpress.com" target="_blank"><img src="https://secure.gravatar.com/avatar/686f2fcfa2e7f34ed429972938f880b5?s=160&d=identicon&r=g" height="42" width="42" />

--- a/2019/index.html
+++ b/2019/index.html
@@ -28,6 +28,9 @@ title: VimConf 2019 - An international Vim Conference
 <div class="container">
   <div class="justify-content-center">
     <div class="jumbotron text">
+      <div id="youtube">
+        <iframe width="560" height="315" src="https://www.youtube.com/embed/kgUciluS-ys?listType=playlist&amp;list=PLx8bw5NQypskQlEGupVqoUBBJtRmNXLet" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </div>
       <div id="billboard">
         <div class="row">
           <div class="logo col-sm-4 justify-content-center">


### PR DESCRIPTION
* YouTube のプレイリストを追加
  * クエリパラメータは[ここ](https://developers.google.com/youtube/player_parameters?hl=ja)を参照した
* `Official Blog` が飛ばないのを修正

ローカルでの動作確認はしてないです…
Chrome の DevTools で直接編集・確認してた感じです。

# Before

<img width="1664" alt="スクリーンショット 2019-12-06 18 41 28" src="https://user-images.githubusercontent.com/48169/70312988-1105c180-1858-11ea-827a-8372519781a0.png">


# After

![image](https://user-images.githubusercontent.com/48169/70312911-e3207d00-1857-11ea-8b0b-9de076d5ae3b.png)
