### PR TITLE
Deploy pages using GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+name: Build and Deploy Jekyll site
+
+on:
+  push:
+    branches:
+      - gh-pages
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: build with jekyll
+        run: |
+          sh ./_scripts/docker_jekyll jekyll build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    needs:
+      - build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
このプルリクエストは、GitHub PagesにJekyllサイトをビルドしてデプロイするための新しいGitHub Actionsワークフローを紹介します。最も重要な変更点は、ワークフローの定義、パーミッションの設定、ビルドとデプロイのジョブの指定です。

ちなみに設定ではまだ切り替えて試していないので、これをマージした後に動かしてみる予定です

### GitHub Actions Workflow for Jekyll Site Deployment：

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R1-R39): gh-pages`ブランチへのプッシュをトリガーとする 「Build and Deploy Jekyll site 」という新しいワークフローを作成しました。
* パーミッション： パーミッション: コンテンツ読み込み、ページ書き込み、id-token書き込みのパーミッションを設定。
* ビルドジョブ： リポジトリをチェックアウトし、Dockerスクリプトを使用してJekyllでサイトをビルドし、ビルド成果物をアップロードするジョブを追加しました。
* デプロイジョブ： ビルドジョブの正常終了に依存する、ビルドされたサイトをGitHub Pagesにデプロイするジョブを追加しました。

