### PR TITLE
fix: build page

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: build with jekyll
-        run: |
-          sh ./_scripts/docker_jekyll jekyll build
+        uses: actions/jekyll-build-pages@v1
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
This pull request includes an update to the build process in the GitHub Actions workflow file. The most important change is the replacement of a custom script with a standardized GitHub Action for building with Jekyll.

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L21-R21): Replaced the custom script `sh ./_scripts/docker_jekyll jekyll build` with the `actions/jekyll-build-pages@v1` action for building with Jekyll.