### PR TITLE
fix: 2025年をjkellyから除外

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,7 @@ exclude:
   - 'README.md'
   - 'vendor'
   - 'go.mod'
+  - '2025'
 # デフォルトと同じだが「utf-8で記事を書こう」という宣言的な意味合で残した。
 encoding: utf-8
 


### PR DESCRIPTION
https://github.com/vim-jp/vimconf.org/actions/runs/13309097100/job/37166853836


```
             ERROR: YOUR SITE COULD NOT BE BUILT:
                    ------------------------------------
                    Invalid YAML front matter in /github/workspace/2025/src/pages/en.astro
```
2025年分もjkellyでビルドしようとしていたが、Astroを使っているので除外