### PR TITLE
企業スポンサーの画像パスを正しく取得

### DIFF
--- a/2025/src/components/Sponsors/Company.astro
+++ b/2025/src/components/Sponsors/Company.astro
@@ -1,4 +1,11 @@
 ---
+import type { ImageMetadata } from "astro";
+
+// import.meta.globで画像をlazyロード
+const images = import.meta.glob<{ default: ImageMetadata }>(
+  "/src/assets/sponsors/*.{png,svg}",
+);
+
 type Props = {
   sponsor: {
     rank: "platinum" | "gold" | "silver" | "bronze";
@@ -11,14 +18,14 @@ type Props = {
 const props = Astro.props;
 const { rank, name, url, image } = props.sponsor;
 
+const imagePath = `/src/assets/sponsors/${image}`;
 let imageUrl = "";
-try {
-  const module = await import(
-    /* @vite-ignore */ `../../assets/sponsors/${image}?url`
-  );
-  imageUrl = module.default;
-} catch (e) {
-  console.error(`Icon not found: ${image}`);
+
+if (images[imagePath]) {
+  const imageModule = await images[imagePath]();
+  imageUrl = imageModule.default.src;
+} else {
+  console.error(`Image not found: ${imagePath}`);
 }
 
 // ランクごとのスタイル設定


### PR DESCRIPTION
手元でビルドしたところ、imgタグのsrcにパスがセットされ、そのファイルが存在することを確認
<img width="527" height="101" alt="image" src="https://github.com/user-attachments/assets/d8803534-185c-421d-b7e3-85a69c4f1542" />
<img width="752" height="148" alt="image" src="https://github.com/user-attachments/assets/27f850ce-e667-4a9c-aa31-5b3460398b46" />
