### PR TITLE
fix(Schedule): 「スケジュールを見る」ボタンを有効化

### DIFF
--- a/2025/src/components/Top.astro
+++ b/2025/src/components/Top.astro
@@ -63,7 +63,6 @@ import { ExternalLink, Heart, Zap } from "@lucide/astro";
           <ExternalLink class="ml-2 h-4 w-4" />
         </a></button
       ><button
-        disabled
         class="inline-flex h-10 w-auto items-center justify-center gap-2 rounded-md border border-emerald-600 bg-background px-4 py-2 text-sm font-medium whitespace-nowrap text-emerald-700 ring-offset-background transition-colors hover:bg-emerald-50 hover:text-accent-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0"
         ><a href="#schedule">スケジュールを見る</a></button
       >


### PR DESCRIPTION
Fix: #208
<img width="897" height="653" alt="image" src="https://github.com/user-attachments/assets/b15c15ca-97a7-4ddb-864a-f2c0cce4fbe0" />
