### PR TITLE
Asia/Tokyoのタイムスタンプに固定

### DIFF
--- a/2025/src/components/Schedule/index.ts
+++ b/2025/src/components/Schedule/index.ts
@@ -19,7 +19,10 @@ export const getScheduleCardStyle = (title: string) => {
 };
 
 export const formatTime = (date: Date): string => {
-  const hours = date.getHours().toString().padStart(2, "0");
-  const minutes = date.getMinutes().toString().padStart(2, "0");
-  return `${hours}:${minutes}`;
+  return new Intl.DateTimeFormat("ja-JP", {
+    timeZone: "Asia/Tokyo",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(date);
 };


### PR DESCRIPTION
ローカルの表示が変わらないことを確認しています。

<img width="1928" height="1120" alt="CleanShot 2025-08-19 at 21 46 57@2x" src="https://github.com/user-attachments/assets/5977c80d-c97e-445c-85e4-eb89a50eca6e" />
